### PR TITLE
Attempt to fix issue during combat where mafia writes an empty round

### DIFF
--- a/KoLmafia/scripts/ScotchLog.ash
+++ b/KoLmafia/scripts/ScotchLog.ash
@@ -899,6 +899,9 @@ void parseLog(string runLog, string fName) {
             //   Before doing this, you have to make sure the line is long enough
             //   to possibly contain the player's name, tho. (Thanks, 3BH, for 
             //   helping track this weird error down.)
+			if (count(split_string(currLine,": ")) == 1){
+                continue;
+            }
             if (length(split_string(currLine,": ")[1]) > length(myName)){
                 if (substring(split_string(currLine,": ")[1],0,length(myName)) == myName){
                     // This detects if it's a statement about you! And this cuts out


### PR DESCRIPTION
scotchlog will die if a round starts with a "blank" and its over double digits
see example combat
Round 8: 
Round 8: ClickClick pulls out a tiny bowling ball and hurls it at your opponent, striking it for 11 damage.
Round 8: God Lobster takes 11 damage.
Round 8: God Lobster takes 1 damage.
Round 8: threebullethamburgler casts SUMMON LOVE STINKBUG!
Round 9: 
Round 9: ClickClick pulls out a tiny bowling ball and hurls it at your opponent, striking it for 12 damage.
Round 9: God Lobster takes 12 damage.
Round 9: God Lobster takes 17 damage.
Round 9: God Lobster takes 1 damage.
Round 9: threebullethamburgler casts GOOD MEDICINE!
Round 10: 
Round 10: You gain 175 hit points
Round 10: ClickClick pulls out a tiny bowling ball and hurls it at your opponent, striking it for 10 damage.
Round 10: God Lobster takes 10 damage.
Round 10: God Lobster takes 17 damage.
Round 10: God Lobster takes 1 damage.
Round 10: threebullethamburgler casts SNAKEWHIP!

it gives up on round 10
I think its due to if (length(currLine) < 9){
line 662
so the message, which is a blank line (mafia logging error?) gets far enough in parsing that it tries to find this if (length(split_string(currLine,": ")[1]) > length(myName)){ line 903
and dies thusly 

Array index [1] out of bounds (1) (ScotchLog.ash, line 903)
  at generateRawLog (ScotchLog.ash:1308)
  at executeCommand (ScotchLog.ash:1358)
  at main (ScotchLog.ash:1414)

I have cheated and added this line
if (count(split_string(currLine,": ")) == 1){
                continue;
            }
in place of existing line 902 let me know if you have a different or better solution for this!